### PR TITLE
Use theme's list separator color instead of a hard-coded value for the default changelog row

### DIFF
--- a/ChangeLogLibrary/src/main/res/layout-v14/changelogrow_layout.xml
+++ b/ChangeLogLibrary/src/main/res/layout-v14/changelogrow_layout.xml
@@ -47,6 +47,6 @@
             android:layout_marginBottom="1dp"
             android:layout_marginLeft="12dp"
             android:layout_marginRight="12dp"
-            android:background="#DADADC" />
+            android:background="?android:attr/listDivider" />
 
 </LinearLayout>

--- a/ChangeLogLibrary/src/main/res/layout/changelogrow_layout.xml
+++ b/ChangeLogLibrary/src/main/res/layout/changelogrow_layout.xml
@@ -47,6 +47,6 @@
             android:layout_marginBottom="1dp"
             android:layout_marginLeft="12dp"
             android:layout_marginRight="12dp"
-            android:background="#DADADC" />
+            android:background="?android:attr/listDivider" />
 
 </LinearLayout>


### PR DESCRIPTION
The current hard-coded color for the changelog row list separator doesn't look very nice in the Holo Dark theme:

![device-2014-06-21-213649](https://cloud.githubusercontent.com/assets/42659/3349691/73686f30-f973-11e3-923a-489b78737a44.png)

I think it looks better if we use the theme's list separator color:

![device-2014-06-21-213309](https://cloud.githubusercontent.com/assets/42659/3349687/28f13748-f973-11e3-9883-9e93317c87b4.png)
