### PR TITLE
Add support for AboutLibraries

### DIFF
--- a/ChangeLogLibrary/src/main/res/values/strings.xml
+++ b/ChangeLogLibrary/src/main/res/values/strings.xml
@@ -21,4 +21,17 @@
     <!-- Prefix for Improvement type change log -->
     <string name="changelog_row_prefix_improvement">[b]New:[/b]</string>
 
+    <!-- Support for AboutLibraries -->
+    <string name="define_changeloglib"/>
+    <string name="library_changeloglib_author">Gabriele Mariotti</string>
+    <string name="library_changeloglib_authorWebsite">https://github.com/gabrielemariotti</string>
+    <string name="library_changeloglib_libraryName">ChangeLog Library</string>
+    <string name="library_changeloglib_libraryDescription">ChangeLog Library provides an easy way to display a change log in your Android app.</string>
+    <string name="library_changeloglib_libraryWebsite">https://github.com/gabrielemariotti/changeloglib</string>
+    <string name="library_changeloglib_libraryVersion">2.0.0</string>
+    <string name="library_changeloglib_isOpenSource">true</string>
+    <string name="library_changeloglib_repositoryLink">https://github.com/gabrielemariotti/changeloglib</string>
+    <string name="library_changeloglib_classPath">it.gmariotti.changelibs</string>
+    <string name="library_changeloglib_licenseId">apache_2_0</string>
+
 </resources>


### PR DESCRIPTION
This PR adds support for [AboutLibraries](https://github.com/mikepenz/AboutLibraries). By adding these additions in `strings.xml`, AboutLibraries automatically recognizes this library and shows the correct license and author information.

This definition is built using the [definition generator](http://def-builder.mikepenz.com/) on the AboutLibraries website.

I would like to merge these changes as I'm using changeloglib and I would like to use AboutLibraries with an appropriate attribution :-)
